### PR TITLE
docs: correct typos in atom_cheatsheet.tex

### DIFF
--- a/atom_cheatsheet.tex
+++ b/atom_cheatsheet.tex
@@ -80,7 +80,7 @@
 \keys{Ctrl + Shift + left} / \keys{right}                  & Select backward/forward one word \\ \hline
 \keys{Ctrl + Backspace} / \keys{Del}                       & Delete to the beginning/end of word \\ \hline
 
-\keys{Ctrl + Home}                                         & Go to begining \\ \hline
+\keys{Ctrl + Home}                                         & Go to beginning \\ \hline
 \keys{Ctrl + End}                                          & Go to end \\ \hline
 \keys{Ctrl + Right}                                        & Next word \\ \hline
 \keys{Ctrl + Left}                                         & Previous word \\ \hline
@@ -98,7 +98,7 @@
 \keys{Ctrl + \textbf{l}}                                   & Se\textbf{l}ect line \\ \hline
 \keys{Ctrl + Alt + \textbf{m}}                             & Select code inside \textbf{m}atching brackets \\ \hline
 \keys{Ctrl + \textbf{a}}                                   & Select \textbf{a}ll \\ \hline
-\keys{Ctrl + Shift + Home}                                 & Select to begining \\ \hline
+\keys{Ctrl + Shift + Home}                                 & Select to beginning \\ \hline
 \keys{Ctrl + Shift + End}                                  & Select to end \\ \hline
 
 \keys{Alt + Shift + Down}                                  & Add selection below \\ \hline
@@ -175,13 +175,13 @@
 \hline
 \rowcolor[gray]{.8}
 \multicolumn{2}{|l|}{\bfseries GitHub Integration}\\ \hline
-\keys{Alt + g} then \keys{\textbf{b}}                      & Open on Github: \textbf{b}lame \\ \hline
-\keys{Alt + g} then \keys{\textbf{c}}                      & Open on Github: \textbf{c}opy-url \\ \hline
-\keys{Alt + g} then \keys{g}                               & Open on Github: repository \\ \hline
-\keys{Alt + g} then \keys{\textbf{h}}                      & Open on Github: \textbf{h}istory \\ \hline
-\keys{Alt + g} then \keys{\textbf{i}}                      & Open on Github: \textbf{i}ssues \\ \hline
-\keys{Alt + g} then \keys{o}                               & Open on Github: file \\ \hline
-\keys{Alt + g} then \keys{\textbf{r}}                      & Open on Github: b\textbf{r}anch-compare \\ \hline
+\keys{Alt + g} then \keys{\textbf{b}}                      & Open on GitHub: \textbf{b}lame \\ \hline
+\keys{Alt + g} then \keys{\textbf{c}}                      & Open on GitHub: \textbf{c}opy-url \\ \hline
+\keys{Alt + g} then \keys{g}                               & Open on GitHub: repository \\ \hline
+\keys{Alt + g} then \keys{\textbf{h}}                      & Open on GitHub: \textbf{h}istory \\ \hline
+\keys{Alt + g} then \keys{\textbf{i}}                      & Open on GitHub: \textbf{i}ssues \\ \hline
+\keys{Alt + g} then \keys{o}                               & Open on GitHub: file \\ \hline
+\keys{Alt + g} then \keys{\textbf{r}}                      & Open on GitHub: b\textbf{r}anch-compare \\ \hline
 \end{tabular}
 
 \vspace{5mm}


### PR DESCRIPTION
I corrected minor typographical errors in the atom_cheatsheet.tex file, including 'begining' to 'beginning' and 'Github' to 'GitHub'.